### PR TITLE
skip unrecognized sections, subsections, and variables

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -49,6 +49,9 @@
 // without a subsection name, its values are stored with the empty string used
 // as the key.
 //
+// If there is a section that does not correspond to a struct field, the
+// section is skipped.
+//
 // The functions in this package panic if config is not a pointer to a struct,
 // or when a field is not of a suitable type (either a struct or a map with
 // string keys and pointer-to-struct values).

--- a/read_test.go
+++ b/read_test.go
@@ -189,16 +189,16 @@ var readtests = []struct {
 	{"[section]", &cBasic{Section: cBasicS1{PName: nil}}, true},
 	{"[section]\npname=value", &cBasic{Section: cBasicS1{PName: newString("value")}}, true},
 	// section name not matched
-	{"\n[nonexistent]\nname=value", &cBasic{}, false},
+	{"\n[nonexistent]\nname=value", &cBasic{}, true},
 	// subsection name not matched
-	{"\n[section \"nonexistent\"]\nname=value", &cBasic{}, false},
+	{"\n[section \"nonexistent\"]\nname=value", &cBasic{}, true},
 	// variable name not matched
-	{"\n[section]\nnonexistent=value", &cBasic{}, false},
+	{"\n[section]\nnonexistent=value", &cBasic{}, true},
 	// hyphen in name
 	{"[hyphen-in-section]\nhyphen-in-name=value", &cBasic{Hyphen_In_Section: cBasicS2{Hyphen_In_Name: "value"}}, true},
 	// ignore unexported fields
-	{"[unexported]\nname=value", &cBasic{}, false},
-	{"[exported]\nunexported=value", &cBasic{}, false},
+	{"[unexported]\nname=value", &cBasic{}, true},
+	{"[exported]\nunexported=value", &cBasic{}, true},
 	// 'X' prefix for non-upper/lower-case letters
 	{"[甲]\n乙=丙", &cUni{X甲: cUniS1{X乙: "丙"}}, true},
 	//{"[section]\nxname=value", &cBasic{XSection: cBasicS4{XName: "value"}}, false},
@@ -214,8 +214,8 @@ var readtests = []struct {
 	{"\n[m1]\nmulti\nmulti=value1\nmulti=value2", &cMulti{M1: cMultiS1{[]string{"value1", "value2"}}}, true},
 	// named slice type: do not treat as multi-value
 	{"\n[m2]", &cMulti{}, true},
-	{"\n[m2]\nmulti=value", &cMulti{}, false},
-	{"\n[m2]\nmulti=value1\nmulti=value2", &cMulti{}, false},
+	{"\n[m2]\nmulti=value", &cMulti{}, true},
+	{"\n[m2]\nmulti=value1\nmulti=value2", &cMulti{}, true},
 }}, {"type:string", []readtest{
 	{"[section]\nname=value", &cBasic{Section: cBasicS1{Name: "value"}}, true},
 	{"[section]\nname=", &cBasic{Section: cBasicS1{Name: ""}}, true},

--- a/set.go
+++ b/set.go
@@ -197,7 +197,7 @@ func set(cfg interface{}, sect, sub, name string, blank bool, value string) erro
 	vCfg := vPCfg.Elem()
 	vSect, _ := fieldFold(vCfg, sect)
 	if !vSect.IsValid() {
-		return fmt.Errorf("invalid section: section %q", sect)
+		return nil
 	}
 	if vSect.Kind() == reflect.Map {
 		vst := vSect.Type()
@@ -222,13 +222,11 @@ func set(cfg interface{}, sect, sub, name string, blank bool, value string) erro
 		panic(fmt.Errorf("field for section must be a map or a struct: "+
 			"section %q", sect))
 	} else if sub != "" {
-		return fmt.Errorf("invalid subsection: "+
-			"section %q subsection %q", sect, sub)
+		return nil
 	}
 	vVar, t := fieldFold(vSect, name)
 	if !vVar.IsValid() {
-		return fmt.Errorf("invalid variable: "+
-			"section %q subsection %q variable %q", sect, sub, name)
+		return nil
 	}
 	// vVal is either single-valued var, or newly allocated value within multi-valued var
 	var vVal reflect.Value


### PR DESCRIPTION
Changes the behavior to match that of encoding/json, etc., which do
not complain if input data is not fully represented in resulting
struct.

@speter: It seems that it was a conscious design decision to be strict about mapping all input to the struct. Is this a requirement? It actually makes it nearly impossible (AFAICT) to use this to actually parse git config files, which can contain arbitrary top-level sections.

One future improvement could be having gcfg put extraneous unmapped data into a struct field (if present) named `Extra` or tagged with `gcfg:",extra"`, or something like that.
