### PR TITLE
Set an empty slice for blank values instead of a nil slice

### DIFF
--- a/set.go
+++ b/set.go
@@ -240,7 +240,7 @@ func set(cfg interface{}, sect, sub, name string, blank bool, value string) erro
 	// multi-value if unnamed slice type
 	isMulti := vVar.Type().Name() == "" && vVar.Kind() == reflect.Slice
 	if isMulti && blank {
-		vVar.Set(reflect.Zero(vVar.Type()))
+		vVar.Set(reflect.MakeSlice(vVar.Type(), 0, 0))
 		return nil
 	}
 	if isMulti {


### PR DESCRIPTION
Hi!

Thanks for making gcfg.  Given the following struct:

```
struct {
    Section struct {
        Color    []string
    }
}
```

I would like to be able to distinguish between this config:

```
[section]
```

and this config:

```
[section]
color
```

In the former case, I would like to use some default values for `Color`, but in the latter case I would like to leave `Color` empty.  Unfortunately, gcfg currently sets `Color` to `nil` in both cases so there's no way to distinguish between them.

This pull request changes the behavior so that in the latter config, `Color` will be set to the empty slice instead of `nil`, allowing me to distinguish between them.  Could this be applied to gcfg?

Thanks!
