### PR TITLE
user-supplied variable names -- vote for inclusion in v1

### DIFF
--- a/idx.go
+++ b/idx.go
@@ -1,0 +1,53 @@
+package gcfg
+
+import (
+	"strings"
+)
+
+// Idx represents a handle to use as map key when looking up variable names in a
+// case-insensitive manner.
+type Idx idx
+
+type idx struct {
+	n string
+}
+
+// Idxer implements case-insensitive lookup of variables in a section.
+type Idxer struct {
+	names map[string]struct{}
+}
+
+// Idx returns the Idx for the variable n, matched case-insensitively.
+// In case of no match, the Idx returned is one that does not exist in the map.
+func (i Idxer) Idx(n string) Idx {
+	if i.names == nil {
+		return Idx{}
+	}
+	for in := range i.names {
+		if strings.EqualFold(n, in) {
+			return Idx{in}
+		}
+	}
+	return Idx{}
+}
+
+// Names returns the variable names for the section. The case and order of names
+// is undefined.
+func (i Idxer) Names() []string {
+	if i.names == nil {
+		return nil
+	}
+	l := make([]string, 0, len(i.names))
+	for n := range i.names {
+		l = append(l, n)
+	}
+	return l
+}
+
+// add adds n to Idxer. Checking for duplicates is the caller's responsibility.
+func (i *Idxer) add(n string) {
+	if i.names == nil {
+		i.names = make(map[string]struct{})
+	}
+	i.names[n] = struct{}{}
+}

--- a/idx_test.go
+++ b/idx_test.go
@@ -1,0 +1,63 @@
+package gcfg
+
+import (
+	"testing"
+)
+
+var idxerIdxCaseTests = [][]string{
+	[]string{"a", "A"},
+	[]string{"Hello", "HELLO", "hello"},
+}
+
+func TestIdxerIdxCase(t *testing.T) {
+	var idxer Idxer
+	for _, ns := range idxerIdxCaseTests {
+		idxer.add(ns[0])
+		for _, ns := range idxerIdxCaseTests {
+			idx := idxer.Idx(ns[0])
+			for _, n := range ns[1:] {
+				if idx2 := idxer.Idx(n); idx != idx2 {
+					t.Errorf("Idxer.Idx(%q)==%q; "+
+						"want same as Idxer.Idx(%q)==%q", n, idx, ns[0], idx2)
+				}
+			}
+		}
+	}
+}
+
+var idxerNamesTests = [][]string{
+	[]string{},
+	[]string{"a"},
+	[]string{"a", "b"},
+}
+
+func TestIdxerNames(t *testing.T) {
+	for _, ns := range idxerNamesTests {
+		var idxer Idxer
+		vals := make(map[Idx]int)
+		for i, n := range ns {
+			idxer.add(n)
+			vals[idxer.Idx(n)] = i
+		}
+		ins := idxer.Names()
+		if len(ns) != len(ins) {
+			t.Errorf("len(Idxer.Names())=%d; want len(ns)=%d; ns=%v, ins=%v",
+				len(ins), len(ns), ns, ins)
+		}
+		seen := make(map[int]struct{})
+		for _, n := range ins {
+			i := idxer.Idx(n)
+			v := vals[i]
+			if _, exists := seen[v]; exists {
+				t.Errorf("Idxer.Names()=%v contains duplicate; seen=%v",
+					ins, seen)
+			} else {
+				seen[v] = struct{}{}
+			}
+		}
+		if len(seen) != len(ns) {
+			t.Errorf("len(seen)=%d; want len(Idxer.Names())=%d; ns=%v",
+				len(seen), len(ns), ns)
+		}
+	}
+}

--- a/read_test.go
+++ b/read_test.go
@@ -95,6 +95,7 @@ type cNumS2 struct {
 	MultiBig []*big.Int
 }
 type cNumS3 struct{ FileMode os.FileMode }
+
 type readtest struct {
 	gcfg string
 	exp  interface{}
@@ -329,5 +330,61 @@ func TestReadFileIntoUnicode(t *testing.T) {
 	}
 	if "丙" != res.X甲.X乙 {
 		t.Errorf("got %q, wanted %q", res.X甲.X乙, "丙")
+	}
+}
+
+type cUserVar struct {
+	UserVar  cUserVarS
+	UserVarM cUserVarMS
+}
+type cUserVarS struct {
+	Idxer
+	V map[Idx]*string
+}
+type cUserVarMS struct {
+	Idxer
+	V map[Idx]*[]string
+}
+
+func TestReadStringIntoUserVar(t *testing.T) {
+	res := &cUserVar{}
+	cfg := "[uservar]\nname=value"
+	err := ReadStringInto(res, cfg)
+	if err != nil {
+		t.Fatalf("ReadStringInto(%v, %q)=%v; want ok", &cUserVar{}, cfg, err)
+	}
+	s := &res.UserVar
+	ns := s.Names()
+	if len(ns) != 1 {
+		t.Fatalf("Idxer.Names()=%d; want length 1", ns)
+	}
+	if n, n0 := s.Idx("name"), s.Idx(ns[0]); n != n0 {
+		t.Fatalf("Idxer.Idx(Idxer.Names()[0])=%q; "+
+			"want same as Idxer.Idx(\"name\")=%q", n0, n)
+	}
+	if v := s.V[res.UserVar.Idx("name")]; *v != "value" {
+		t.Fatalf("V[Idxer.Idx(\"name\")]=%q; want \"value\"", v)
+	}
+}
+
+func TestReadStringIntoUserVarMulti(t *testing.T) {
+	res := &cUserVar{}
+	cfg := "[uservarm]\nname=value1\nname=value2"
+	err := ReadStringInto(res, cfg)
+	if err != nil {
+		t.Fatalf("ReadStringInto(%v, %q)=%v; want ok", &cUserVar{}, cfg, err)
+	}
+	s := &res.UserVarM
+	ns := s.Names()
+	if len(ns) != 1 {
+		t.Fatalf("Idxer.Names()=%d; want length 1", ns)
+	}
+	if n, n0 := s.Idx("name"), s.Idx(ns[0]); n != n0 {
+		t.Fatalf("Idxer.Idx(Idxer.Names()[0])=%q; "+
+			"want same as Idxer.Idx(\"name\")=%q", n0, n)
+	}
+	if v := s.V[s.Idx("name")]; !reflect.DeepEqual(
+		*v, []string{"value1", "value2"}) {
+		t.Fatalf("V[Idxer.Idx(\"name\")]=%q; want \"value\"", v)
 	}
 }


### PR DESCRIPTION
**Vote for this tentative pull request (PR) to be merged into branch `v1` either by using :+1: or by adding a comment describing your use case (and ideally link to source).** Other (constructive) feedback is also welcome.

Currently (in the `v1` branch) all variable names are supplied by the developer (who implements the configuration struct) as field names (or in field tags). In some situations it is useful to allow the user (who edits the configuration file) to define arbitrary variable names. An example of such usage is the `[alias]` section in [`.gitconfig`](https://git-scm.com/docs/git-config).

This PR adds support for user-supplied variables. A section can contain either all developer-supplied or all user-supplied variables. With user-supplied variables the variable names are case-insensitive (so it is not as simple as a `map[string]Something`), and the order of variables is not preserved. This is to maintain consistency with developer-supplied variables.

A section with user-defined variables is declared as a struct with two members: an embedded `gcfg.Idxer` and a `map[gcfg.Idx]*Something`, for example:

```
var cfg = &struct {
    Alias struct {
        gcfg.Idxer
        Vals map[gcfg.Idx]*string
    }
}{}
```

After using `gcfg.Read*Into`, looking up a variable is done as follows:

```
val := cfg.Alias.Vals[cfg.Alias.Idx("lg")]
```

Iterating through the variables is done as follows (the case and order of names is undefined):

```
for _, name := range cfg.Alias.Names() {
    val := cfg.Alias.Vals[cfg.Alias.Idx(name)]
    ...
}
```
