### PR TITLE
Adding support for sections defined as a map[string]string

### DIFF
--- a/read_test.go
+++ b/read_test.go
@@ -376,3 +376,23 @@ func TestReadStringIntoExtraData(t *testing.T) {
 		t.Errorf("res.Section.Name=%q; want %q", res.Section.Name, "value")
 	}
 }
+
+func TestStringStringMapSection(t *testing.T) {
+	res := &struct {
+		Section map[string]string
+	}{}
+	cfg := `
+	[section]
+	key = value
+	key2 = value2`
+	err := ReadStringInto(res, cfg)
+	if err != nil {
+		t.Error(err)
+	}
+	if res.Section["key"] != "value" {
+		t.Errorf("res.Section.Name=%q; want %q", res.Section["key"], "value")
+	}
+	if res.Section["key2"] != "value2" {
+		t.Errorf("res.Section.Name=%q; want %q", res.Section["key2"], "value2")
+	}
+}

--- a/set.go
+++ b/set.go
@@ -232,11 +232,24 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 	}
 	if isSubsect {
 		vst := vSect.Type()
+		if vst.Key().Kind() == reflect.String && vst.Elem().Kind() == reflect.String {
+			if vSect.IsNil() {
+				vSect.Set(reflect.MakeMap(vst))
+			}
+			if value != "" {
+				if sub != "" {
+					vSect.SetMapIndex(reflect.ValueOf(sub+" "+name), reflect.ValueOf(value))
+				} else {
+					vSect.SetMapIndex(reflect.ValueOf(name), reflect.ValueOf(value))
+				}
+			}
+			return nil
+		}
 		if vst.Key().Kind() != reflect.String ||
 			vst.Elem().Kind() != reflect.Ptr ||
 			vst.Elem().Elem().Kind() != reflect.Struct {
 			panic(fmt.Errorf("map field for section must have string keys and "+
-				" pointer-to-struct values: section %q", sect))
+				" pointer-to-struct or string values: section %q", sect))
 		}
 		if vSect.IsNil() {
 			vSect.Set(reflect.MakeMap(vst))


### PR DESCRIPTION
Hi,

This is a patch we've been using for a while which allows sections to be a simple `map[string]string`. We've found it useful for cases where we want to have a section with a user-definable set of keys.

I'm not sure if this is something you'd like to see in gcfg or not? It's more permissive than the current model which might not be the direction you want to take it. Alternatively there might be another way to achieve the same effect which I'm not aware of.

Thanks!
