### PR TITLE
Skip file header BOM

### DIFF
--- a/read.go
+++ b/read.go
@@ -221,6 +221,9 @@ func ReadStringInto(config interface{}, str string) error {
 
 // ReadFileInto reads gcfg formatted data from the file filename and sets the
 // values into the corresponding fields in config.
+//
+// For compatibility with files created on Windows, the ReadFileInto skips a
+// single leading UTF8 BOM sequence if it exists.
 func ReadFileInto(config interface{}, filename string) error {
 	f, err := os.Open(filename)
 	if err != nil {
@@ -231,6 +234,15 @@ func ReadFileInto(config interface{}, filename string) error {
 	if err != nil {
 		return err
 	}
+
+	//Skips a single leading UTF8 BOM sequence if it exists.
+	if len(src) > 3 {
+		bom := src[:3]
+		if bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF {
+			src = src[3:]
+		}
+	}
+
 	fset := token.NewFileSet()
 	file := fset.AddFile(filename, fset.Base(), len(src))
 	return readInto(config, fset, file, src)

--- a/read_test.go
+++ b/read_test.go
@@ -338,6 +338,17 @@ func TestReadFileIntoUnicode(t *testing.T) {
 	}
 }
 
+func TestReadFileIntoNotepad(t *testing.T) {
+	res := &struct{ X甲 struct{ X乙 string } }{}
+	err := ReadFileInto(res, "testdata/notepad.ini")
+	if err != nil {
+		t.Error(err)
+	}
+	if "丁" != res.X甲.X乙 {
+		t.Errorf("got %q, wanted %q", res.X甲.X乙, "丁")
+	}
+}
+
 func TestReadStringIntoSubsectDefaults(t *testing.T) {
 	type subsect struct {
 		Color       string

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -127,7 +127,22 @@ func (s *Scanner) Init(file *token.File, src []byte, err ErrorHandler, mode Mode
 	s.ErrorCount = 0
 	s.nextVal = false
 
+	s.skipUTF8Bom()
+
 	s.next()
+}
+
+func (s *Scanner) skipUTF8Bom() {
+	if s.rdOffset+3 >= len(s.src)  {
+		return
+	}
+
+	bom := s.src[s.rdOffset:s.rdOffset+3]
+	if bom[0] != 0xef || bom[1] != 0xbb || bom[2] != 0xbf {
+		return
+	}
+
+	s.rdOffset += 3
 }
 
 func (s *Scanner) error(offs int, msg string) {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -127,22 +127,7 @@ func (s *Scanner) Init(file *token.File, src []byte, err ErrorHandler, mode Mode
 	s.ErrorCount = 0
 	s.nextVal = false
 
-	s.skipUTF8Bom()
-
 	s.next()
-}
-
-func (s *Scanner) skipUTF8Bom() {
-	if s.rdOffset+3 >= len(s.src)  {
-		return
-	}
-
-	bom := s.src[s.rdOffset:s.rdOffset+3]
-	if bom[0] != 0xef || bom[1] != 0xbb || bom[2] != 0xbf {
-		return
-	}
-
-	s.rdOffset += 3
 }
 
 func (s *Scanner) error(offs int, msg string) {

--- a/testdata/notepad.ini
+++ b/testdata/notepad.ini
@@ -1,0 +1,3 @@
+﻿; Comment line
+[甲]
+乙=丁 # Update 乙 to 丁 by notepad on windows


### PR DESCRIPTION
On the Windows platform, the default is to use Notepad to edit ini files.
When saving it in notepad by selecting UTF-8 encoding. 
It will use utf-8 with bom format. 
The three-byte BOM character 0xEF 0xBB 0xBF in the file header causes a parsing error.
Skip BOM character when file scanner is initialized.