### PR TITLE
ReadFileInto skips a single leading UTF8 BOM sequence if it exists.

### DIFF
--- a/read.go
+++ b/read.go
@@ -235,15 +235,22 @@ func ReadFileInto(config interface{}, filename string) error {
 		return err
 	}
 
-	//Skips a single leading UTF8 BOM sequence if it exists.
-	if len(src) > 3 {
-		bom := src[:3]
-		if bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF {
-			src = src[3:]
-		}
-	}
+	// Skips a single leading UTF8 BOM sequence if it exists.
+	src = skipLeadingUtf8Bom(src)
 
 	fset := token.NewFileSet()
 	file := fset.AddFile(filename, fset.Base(), len(src))
 	return readInto(config, fset, file, src)
 }
+
+func skipLeadingUtf8Bom(src []byte) []byte{
+	if len(src) >= 3 {
+		bom := src[:3]
+		if bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF {
+			return src[3:]
+		}
+	}
+	return src
+}
+
+

--- a/read.go
+++ b/read.go
@@ -221,6 +221,9 @@ func ReadStringInto(config interface{}, str string) error {
 
 // ReadFileInto reads gcfg formatted data from the file filename and sets the
 // values into the corresponding fields in config.
+//
+// For compatibility with files created on Windows, the ReadFileInto skips a
+// single leading UTF8 BOM sequence if it exists.
 func ReadFileInto(config interface{}, filename string) error {
 	f, err := os.Open(filename)
 	if err != nil {
@@ -231,6 +234,15 @@ func ReadFileInto(config interface{}, filename string) error {
 	if err != nil {
 		return err
 	}
+
+	//Skips a single leading UTF8 BOM sequence if it exists.
+	if len(src) > 3 {
+		bom := src[:3]
+		if bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF {
+			src = src[3:]
+		}
+	}
+
 	fset := token.NewFileSet()
 	file := fset.AddFile(filename, fset.Base(), len(src))
 	return readInto(config, fset, file, src)

--- a/read.go
+++ b/read.go
@@ -1,6 +1,7 @@
 package gcfg
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,6 +14,7 @@ import (
 )
 
 var unescape = map[rune]rune{'\\': '\\', '"': '"', 'n': '\n', 't': '\t'}
+var utf8Bom = []byte("\ufeff")
 
 // no error: invalid literals should be caught by scanner
 func unquote(s string) string {
@@ -243,14 +245,13 @@ func ReadFileInto(config interface{}, filename string) error {
 	return readInto(config, fset, file, src)
 }
 
-func skipLeadingUtf8Bom(src []byte) []byte{
-	if len(src) >= 3 {
-		bom := src[:3]
-		if bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF {
-			return src[3:]
+func skipLeadingUtf8Bom(src []byte) []byte {
+	lengthUtf8Bom := len(utf8Bom)
+
+	if len(src) >= lengthUtf8Bom {
+		if bytes.Equal(src[:lengthUtf8Bom], utf8Bom) {
+			return src[lengthUtf8Bom:]
 		}
 	}
 	return src
 }
-
-

--- a/read_test.go
+++ b/read_test.go
@@ -1,13 +1,13 @@
 package gcfg
 
 import (
+	"bytes"
 	"encoding"
 	"fmt"
 	"math/big"
 	"os"
 	"reflect"
 	"testing"
-	"bytes"
 )
 
 const (
@@ -417,21 +417,21 @@ func TestPanics(t *testing.T) {
 	}
 }
 
-var utf8bomtests = []struct{
-	id string
+var utf8bomtests = []struct {
+	id  string
 	in  []byte
 	out []byte
 }{
-	{"0 bytes input",[]byte{}, []byte{}},
-	{"3 bytes input (BOM only)",[]byte{0xEF,0xBB,0xBF}, []byte{}},
-	{"3 bytes input (comment only, without BOM)",[]byte(";c\n"), []byte(";c\n")},
-	{"normal input with BOM",[]byte("\xEF\xBB\xBF[section]\nname=value"), []byte("[section]\nname=value")},
-	{"normal input without BOM",[]byte("[section]\nname=value"), []byte("[section]\nname=value")},
+	{"0 bytes input", []byte{}, []byte{}},
+	{"3 bytes input (BOM only)", []byte("\ufeff"), []byte{}},
+	{"3 bytes input (comment only, without BOM)", []byte(";c\n"), []byte(";c\n")},
+	{"normal input with BOM", []byte("\ufeff[section]\nname=value"), []byte("[section]\nname=value")},
+	{"normal input without BOM", []byte("[section]\nname=value"), []byte("[section]\nname=value")},
 }
 
-func testUtf8Bom(t *testing.T, id string, in, out []byte){
+func testUtf8Bom(t *testing.T, id string, in, out []byte) {
 	got := skipLeadingUtf8Bom([]byte(in))
-	if !bytes.Equal(got,out) {
+	if !bytes.Equal(got, out) {
 		t.Errorf("%s.", id)
 	}
 }

--- a/read_test.go
+++ b/read_test.go
@@ -339,6 +339,17 @@ func TestReadFileIntoUnicode(t *testing.T) {
 	}
 }
 
+func TestReadFileIntoNotepad(t *testing.T) {
+	res := &struct{ X甲 struct{ X乙 string } }{}
+	err := ReadFileInto(res, "testdata/notepad.ini")
+	if err != nil {
+		t.Error(err)
+	}
+	if "丁" != res.X甲.X乙 {
+		t.Errorf("got %q, wanted %q", res.X甲.X乙, "丁")
+	}
+}
+
 func TestReadStringIntoSubsectDefaults(t *testing.T) {
 	type subsect struct {
 		Color       string

--- a/testdata/notepad.ini
+++ b/testdata/notepad.ini
@@ -1,0 +1,3 @@
+﻿; Comment line
+[甲]
+乙=丁 # Update 乙 to 丁 by notepad on windows


### PR DESCRIPTION
For compatibility with files created on Windows, ReadFileInto skips a single leading UTF8 BOM sequence if it exists.

- Add ReadFileInto documentation 
- Add test data testdata/notepad.ini
- Add testcase  TestReadFileIntoNotepad

[Related pull request#13](https://github.com/go-gcfg/gcfg/pull/13)