### PR TITLE
support optional section + key/value map as section

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -60,19 +60,51 @@ variable-name=value # comment`
 
 func ExampleReadStringInto_tags() {
 	cfgStr := `; Comment line
-[section]
-var-name=value # comment`
+[tags]
+tag1=value1 # a tag
+tag2=value2 # a second tag`
 	cfg := struct {
-		Section struct {
-			FieldName string `gcfg:"var-name"`
+		Tags map[string]string
+	}{}
+	err := gcfg.ReadStringInto(&cfg, cfgStr)
+	if err != nil {
+		log.Fatalf("Failed to parse gcfg data: %s", err)
+	}
+	for k, v := range cfg.Tags {
+		fmt.Printf("%s = %s\n", k, v)
+	}
+	// Output: tag1 = value1
+	// tag2 = value2
+}
+
+func ExampleReadStringInto_optional_section() {
+	cfgStr := `; Comment line
+        [Section]
+          Name=value`
+	cfg := struct {
+		Optional *struct {
+			Name string
+		}
+		Section *struct {
+			Name string
 		}
 	}{}
 	err := gcfg.ReadStringInto(&cfg, cfgStr)
 	if err != nil {
 		log.Fatalf("Failed to parse gcfg data: %s", err)
 	}
-	fmt.Println(cfg.Section.FieldName)
-	// Output: value
+	if cfg.Optional == nil {
+		fmt.Println("optional not given")
+	} else {
+		fmt.Printf("Optional.Name=%s\n", cfg.Optional.Name)
+	}
+	if cfg.Section == nil {
+		fmt.Println("section not given")
+	} else {
+		fmt.Printf("Section.Name = %s\n", cfg.Section.Name)
+	}
+	// Output: optional not given
+	// Section.Name = value
 }
 
 func ExampleReadStringInto_subsections() {

--- a/read.go
+++ b/read.go
@@ -195,10 +195,10 @@ func readInto(config interface{}, fset *token.FileSet, file *token.File,
 	if err != nil {
 		return err
 	}
-	err = readIntoPass(c, config, fset, file, src, true)
-	if err != nil {
-		return err
-	}
+	//err = readIntoPass(c, config, fset, file, src, true)
+	//if err != nil {
+	//	return err
+	//}
 	return c.Done()
 }
 


### PR DESCRIPTION
This pull request provides support for the following missing features:
- Dynamic Section Content
  using the type `map[string]string` it is possible to catch dynamic section content (key/value) pairs.
  So far only string values are possible. The `Tags` example has been adapted to show real tags.
- Dynamic Sub Section Content
  using the type `map[string]map[string]string` it is possible to catch dynamic sub section content, also.
- Use of Structs as well as Struct Pointers
  for plain sections as well as sub sections it is possible now to use pointers to structs or structs.
- Optional Sections
  for plain sections, the use of a pointer type now allows to identify optional sections. The field is
  `nil` if the section is not given in the config data. It points to an initial struct, if the section is
  given, but no fields. 

There are appropriate examples and tests added.