### PR TITLE
Provide an example of hash sign in tests

### DIFF
--- a/read_test.go
+++ b/read_test.go
@@ -111,6 +111,8 @@ var readtests = []struct {
 	tests []readtest
 }{{"scanning", []readtest{
 	{"[section]\nname=value", &cBasic{Section: cBasicS1{Name: "value"}}, true},
+	// hash sign in value
+	{"[section]\nname=\"val#ue\"", &cBasic{Section: cBasicS1{Name: "val#ue"}}, true},
 	// hyphen in name
 	{"[hyphen-in-section]\nhyphen-in-name=value", &cBasic{Hyphen_In_Section: cBasicS2{Hyphen_In_Name: "value"}}, true},
 	// quoted string value


### PR DESCRIPTION
Provide a living-doc example of a hash sign in a value.

I tried this locally to understand if it was my local marshaller failing, or this library.

It was my local marshaller :)

I thought this example could be useful for others as well (and for catching regressions!).

Thank you for the great work.