### PR TITLE
fix tests to match behavior of strconv.ParseInt since Go 1.13

### DIFF
--- a/types/int_test.go
+++ b/types/int_test.go
@@ -24,8 +24,8 @@ func TestParseInt(t *testing.T) {
 		{"a", Hex, int(0xa), true},
 		{"10", Hex, int(0x10), true},
 		{"-0xa", Hex, int(-0xa), true},
-		{"0x", Hex, int(0x0), true},  // Scanf doesn't require digit behind 0x
-		{"-0x", Hex, int(0x0), true}, // Scanf doesn't require digit behind 0x
+		{"0x", Hex, int(0x0), false},
+		{"-0x", Hex, int(0x0), false},
 		{"-a", Hex, int(-0xa), true},
 		{"-10", Hex, int(-0x10), true},
 		{"x", Hex, int(0), false},

--- a/types/scan_test.go
+++ b/types/scan_test.go
@@ -13,7 +13,7 @@ func TestScanFully(t *testing.T) {
 		ok   bool
 	}{
 		{"a", 'v', int(0), false},
-		{"0x", 'v', int(0), true},
+		{"0x", 'v', int(0), false},
 		{"0x", 'd', int(0), false},
 	} {
 		d := reflect.New(reflect.TypeOf(tt.res)).Interface()


### PR DESCRIPTION
Fixes #17